### PR TITLE
add install.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ qrc_*
 build/
 .vscode/
 *.user
+
+.idea/
+Build/
+cmake-build-debug/

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you use Arch, you can install deepin-topbar in Community repo.
 
 ## Installation
 
-### Build from source code
+### Build from source code method 1
 
 1. Make sure you have installed all dependencies.
 
@@ -96,6 +96,14 @@ $ sudo make install
 ```
 
 The executable binary file could be found at `/usr/bin/deepin-topbar` after the installation is finished.
+
+### Build from source code method 2
+```shell script
+git clone [this repo]
+cd deepin-toolbar
+chmod +x install.sh
+./install.sh
+```
 
 ## Getting help
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,29 @@
+# install script by zimo
+# 1.install all dependencies and tools.
+sudo install qt5* -y
+sudo apt install qttools5-dev -y
+sudo apt install libgsettings-qt-dev -y
+sudo apt install libdde-network-ut* -y
+sudo apt install libdframeworkdbus* -y
+sudo apt install libdbusmenu-qt5-dev -y
+sudo apt install libxcb-ewmh-dev -y
+sudo apt install libxcb-util* -y
+sudo apt install libxtst* -y
+sudo apt install libxcb-im* -y
+sudo apt install libxcb-ic* -y
+sudo apt install libxcb-co* -y
+sudo apt install dde-dock-dev -y
+sudo apt install qtbase5-dev-tools -y
+sudo apt install libdtkwidget-dev -y
+sudo apt install libxcb-composite0-dev -y
+sudo apt install libprocps-dev -y
+sudo apt install cmake -y
+
+# 2. build
+mkdir Build
+cd Build
+cmake ../
+make
+
+# 3. install
+sudo make install

--- a/src/widgets/switchitem.h
+++ b/src/widgets/switchitem.h
@@ -15,7 +15,7 @@ public:
     explicit SwitchItem(QWidget *parent = 0);
 
     const QString text() const { return m_text->text(); }
-    bool checked() const { return m_switch->isChecked(); }
+    bool checked() const { return m_switch->checked(); }
     const QString value() const {return m_value; }
 
 signals:


### PR DESCRIPTION
1. add install.sh to convenient everybody build from source code
2. fix error "/deepin-topbar/src/widgets/switchitem.h:18:45: error: ‘class Dtk::Widget::DSwitchButton’ has no member named ‘isChecked’; did you mean ‘checked’? bool checked() const { return m_switch->isChecked(); }", I think this error is related to dependencies version
3. update readme